### PR TITLE
Ajustes fechas equivocadas T0 y T1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # Cirug-a-conservadora
 Proyecto con archivos guardados en D:\MEGA\Desenlaces cirugía conservadora. Anderson Sáenz es el fellow
+Se ajustaron las fechas en el archivo cirugiaconservadora.dta
+Los cambios fueron estos:
+DR Buenas tardes, 
+Revisado SAP 
+se evidencia que el registro 208 codigo 199641 tiene error en registro de consulta bidisiplinaria
+la cual no es 21/01/2016  sino  25/11/2014   la fecha de recaída esta bién en redcap 03/03/2016 y fecha de mortalidad 30/03/2016 tal como esta en red cap. No hay información sobre el tipo de recaida
+Con respecto al registro 232 codigo la fecha del ultimo control esta mal digitada, es 04/06/2021 no 04/06/2001, este paciente no tiene recaida tal como esta en el red cap


### PR DESCRIPTION
Cambio en dos pacientes por error en la digitación de fechas (registro 208 y 232).
Los ajustes están en la base cirugiaconservadora.dta